### PR TITLE
Add new telemetry headers

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 DB_FOLDER = 'db'
 os.makedirs('db', exist_ok=True)
@@ -12,6 +13,13 @@ SCAN_INTERVAL = 60
 CLIENT_ID = os.getenv('CLIENT_ID', '24a75470-e2e5-45c7-80dc-ac306c1d7875')
 REDIRECT_URL = 'http://127.0.0.1:5111'
 SCOPES = 'project.read asset.create offline asset.read team.read account.read asset.delete'
+
+TELEMETRY_HEADERS = {
+    "x-vendor-name": os.getenv("VENDOR", "@strombergdev"),
+    "x-client-name": os.getenv("CLIENT_NAME", "frameio-python-sync"),
+    "x-client-version": os.getenv("VERSION", "1.0.4"),
+    "x-platform": os.getenv("PLATFORM", platform.system())
+}
 
 # Cache variables used for storing active Frame.io client.
 authenticated_client = None

--- a/server/frameioclient/client.py
+++ b/server/frameioclient/client.py
@@ -3,6 +3,7 @@ import sys
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from config import TELEMETRY_HEADERS
 
 from .download import FrameioDownloader
 
@@ -103,7 +104,8 @@ class FrameioClient(object):
 
     headers = {
       'Authorization': 'Bearer {}'.format(self.token),
-      'x-frameio-client': 'python/{}'.format(self.client_version)
+      'x-frameio-client': "{}/{}".format(TELEMETRY_HEADERS['x-client-name'], TELEMETRY_HEADERS['x-client-version']),
+      **TELEMETRY_HEADERS
     }
 
     adapter = HTTPAdapter(max_retries=self.retry_strategy)


### PR DESCRIPTION
This PR adds additional HTTP headers to make it easier for Frame.io to attribute traffic from this integration.